### PR TITLE
add "own" module root lookup logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,13 @@
  */
 
 var path = require('path');
+var callsite = require('callsite');
 var findup = require('findup-sync');
 
-
 module.exports = function(name) {
+  if (!name) {
+    name = callsite()[1].getFileName();
+  }
   var fullpath = path.dirname(require.resolve(name));
   var dir = findup('package.json', {cwd: fullpath})
   return path.resolve(path.dirname(dir));

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var findup = require('findup-sync');
 
 module.exports = function(name) {
   var fullpath;
-  if (name) {
+  if (arguments.length > 0) {
     fullpath = require.resolve(name);
   } else {
     fullpath = callsite()[1].getFileName();

--- a/index.js
+++ b/index.js
@@ -9,10 +9,13 @@ var callsite = require('callsite');
 var findup = require('findup-sync');
 
 module.exports = function(name) {
-  if (!name) {
-    name = callsite()[1].getFileName();
+  var fullpath;
+  if (name) {
+    fullpath = require.resolve(name);
+  } else {
+    fullpath = callsite()[1].getFileName();
   }
-  var fullpath = path.dirname(require.resolve(name));
-  var dir = findup('package.json', {cwd: fullpath})
-  return path.resolve(path.dirname(dir));
+  var cwd = path.dirname(fullpath);
+  var pkg = findup('package.json', { cwd: cwd });
+  return path.resolve(path.dirname(pkg));
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     }
   ],
   "dependencies": {
+    "callsite": "^1.0.0",
     "findup-sync": "~0.1.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "callsite": "^1.0.0",
-    "findup-sync": "~0.1.2"
+    "findup-sync": "^0.4.2"
   },
   "keywords": [
     "cwd",


### PR DESCRIPTION
So if you invoke the module with no arguments,
then the module root of the file that is invoking
the function will be returned.

i.e. given file `/foo/bar/t.js`:

``` js
var root = moduleRoot();
// "/foo/bar"
```
